### PR TITLE
Refactor delete requests to use rate limiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ async function main() {
     }
 
     // Only delete releases after the number to keep
-    const releasesToPurge = appReleases.slice(0, -toKeep);
+    const releasesToPurge = appReleases.slice(0, toKeep);
 
     core.debug(`Release IDs to purge: ${JSON.stringify(releasesToPurge)}`);
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/mx51/AppCenter-Purge-Github-Action#readme",
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "cross-fetch": "^3.1.5"
+    "cross-fetch": "^3.1.5",
+    "rate-limiter-flexible": "^2.3.10"
   }
 }


### PR DESCRIPTION
# What

Rate limit delete requests (why) to avoid getting rate limit banned

# How

Using `rate-limiter-flexible` with an in memory queue to limit requests. This allows us to tell Node to fire all our requests in parallel and then rely on the queue to handle meeting the rate limit requirement. 

What this means is we can fire off as many requests as possible as quickly as possible (possibly taking advantage of multiple threads) until we hit the rate limit and backoff.

The rate limiter config (index.js lines 9 - 16) needs to be set, or come from come config maybe? Currently (as an example) it is set as max. 1 request (points) per 2 seconds (duration). And requests beyond that will get added to the queue (maxQueueSize 100). If the queue overflows, these requests will return an error, same as if the request had failed (but message something like "Queue is full"). There's probably no limit on the queue size (beyond the max integer in Node & memory on the runner), so could probably up that to some ridiculous value.

# Note

- Although I added a node_module dep, I didn't check in the files because I wanted to keep the PR neat, so if you want to stick with checking in the deps will need to do another `npm install` and then commit that.
- We can avoid checking all the deps by bundling all the actual deps at build time (happy to add that if you want)